### PR TITLE
Improve latency and reduce memory usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ serde_json = "1.0.66"
 serde = { version = "1.0.127", features = ["derive"] }
 libc = "0.2.66"
 rodio = { version = "0.14.0", git = "https://github.com/orlp/rodio/", rev = "772b7f6" }
+once_cell = "1.8.0"
+flume = "0.10.9"
 
 [target.'cfg(windows)'.dependencies]
 thread-priority = "0.2.4"

--- a/src/play_sound.rs
+++ b/src/play_sound.rs
@@ -1,17 +1,57 @@
 pub mod sound {
-    use std::thread;
+    use once_cell::sync::Lazy;
+    use rodio::source::Buffered;
+    use rodio::{source::Source, Decoder, OutputStream};
+    use std::collections::HashMap;
     use std::fs::File;
     use std::io::BufReader;
-    use rodio::{Decoder, OutputStream, source::Source};
+    use std::sync::Mutex;
+    use std::thread;
+
+    type SoundSource = Buffered<Decoder<BufReader<File>>>;
+
+    static GLOBAL_DATA: Lazy<Mutex<HashMap<String, SoundSource>>> = Lazy::new(|| {
+        let m = HashMap::new();
+        Mutex::new(m)
+    });
+
+    static THREAD_POOL_SENDER: Lazy<flume::Sender<String>> = Lazy::new(|| {
+        let (tx, rx) = flume::unbounded();
+        for _ in 0..10 {
+            let rxc = rx.clone();
+            thread::spawn(move || {
+                worker(rxc);
+            });
+        }
+        tx
+    });
 
     pub fn play_sound(name: String) {
-        let file_name = format!("{}", name);
-        thread::spawn(move|| {
-            let (_stream, stream_handle) = OutputStream::try_default().unwrap();
-            let file = BufReader::new(File::open(&file_name[..]).unwrap());
-            let source = Decoder::new(file).unwrap();
-            drop(stream_handle.play_raw(source.convert_samples()));
-            std::thread::sleep(std::time::Duration::from_millis(700));
-        });
+        THREAD_POOL_SENDER
+            .send(name)
+            .expect("Couldn't send name to threadpool");
+    }
+
+    pub fn worker(rx_channel: flume::Receiver<String>) {
+        let (_stream, stream_handle) = OutputStream::try_default().unwrap();
+        loop {
+            let name = rx_channel
+                .recv()
+                .expect("Couldn't receive file name in worker thread");
+            let file_name = format!("{}", name);
+            let source = {
+                let mut sound_map = GLOBAL_DATA.lock().unwrap();
+                sound_map
+                    .entry(name.clone())
+                    .or_insert_with(|| {
+                        let file = BufReader::new(File::open(&file_name[..]).unwrap());
+                        Decoder::new(file).unwrap().buffered()
+                    })
+                    .clone()
+            };
+            let sink = rodio::Sink::try_new(&stream_handle).unwrap();
+            sink.append(source);
+            sink.sleep_until_end();
+        }
     }
 }


### PR DESCRIPTION
By using a threadpool, we can reduce thread startup times (minimal impact) and more importantly: cache rodio OutputStream creation which costs about 10-20ms per keypress. And all around reduce allocation.

We also cache file reading in a global hashmap.

Ironically, this caching seems to reduce memory usage in my testing (MacOSX looking at private and total).