### PR TITLE
Caches a worker thread and audio context but discards after 20s of inactivity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1.0.127", features = ["derive"] }
 libc = "0.2.66"
 rodio = { version = "0.14.0", git = "https://github.com/orlp/rodio/", rev = "772b7f6" }
 once_cell = "1.8.0"
+flume = "0.10.9"
 
 [target.'cfg(windows)'.dependencies]
 thread-priority = "0.2.4"

--- a/src/play_sound.rs
+++ b/src/play_sound.rs
@@ -1,12 +1,14 @@
 pub mod sound {
+    use flume::{Receiver, Sender};
     use once_cell::sync::Lazy;
-    use std::thread;
     use rodio::source::Buffered;
+    use rodio::{source::Source, Decoder, OutputStream};
     use std::collections::HashMap;
     use std::fs::File;
     use std::io::BufReader;
     use std::sync::Mutex;
-    use rodio::{ source::Source, Decoder, OutputStream };
+    use std::thread;
+    use std::time::Duration;
 
     type SoundSource = Buffered<Decoder<BufReader<File>>>;
 
@@ -15,23 +17,47 @@ pub mod sound {
         Mutex::new(m)
     });
 
-    pub fn play_sound(name: String) {
-        let file_name = format!("{}", name);
-        thread::spawn(move|| {
-            let (_stream, stream_handle) = OutputStream::try_default().unwrap();
-            let source = {
-                let mut sound_map = GLOBAL_DATA.lock().unwrap();
-                sound_map
-                    .entry(name.clone())
-                    .or_insert_with(|| {
-                        let file = BufReader::new(File::open(&file_name[..]).unwrap());
-                        Decoder::new(file).unwrap().buffered()
-                    })
-                    .clone()
-            };
-            let sink = rodio::Sink::try_new(&stream_handle).unwrap();
-            sink.append(source);
-            sink.sleep_until_end();
+    static WORKER_CHANNEL: Lazy<Mutex<Sender<String>>> = Lazy::new(|| Mutex::new(new_worker()));
+
+    fn new_worker() -> Sender<String> {
+        let (tx, rx) = flume::unbounded();
+        thread::spawn(move || {
+            worker(rx);
         });
+        tx
+    }
+
+    pub fn play_sound(name: String) {
+        let mut tx = WORKER_CHANNEL.lock().unwrap();
+        if tx.is_disconnected() {
+            *tx = new_worker()
+        }
+        tx.send(name).expect("Couldn't send name to threadpool");
+    }
+
+    pub fn worker(rx_channel: Receiver<String>) {
+        let (_stream, stream_handle) = OutputStream::try_default().unwrap();
+        loop {
+            if let Ok(name) = rx_channel.recv_timeout(Duration::from_secs(20)) {
+                let file_name = format!("{}", name);
+                let source = {
+                    let mut sound_map = GLOBAL_DATA.lock().unwrap();
+                    sound_map
+                        .entry(name.clone())
+                        .or_insert_with(|| {
+                            let file = BufReader::new(File::open(&file_name[..]).unwrap());
+                            Decoder::new(file).unwrap().buffered()
+                        })
+                        .clone()
+                };
+                let sink = rodio::Sink::try_new(&stream_handle).unwrap();
+                sink.append(source);
+                sink.detach();
+            } else {
+                // Timeout, time to put this thread to sleep to save CPU cycles (open audio OutputStreams use
+                // around half a CPU millicore, and then CoreAudio uses another 7-10%)
+                break;
+            }
+        }
     }
 }


### PR DESCRIPTION
I figured out where the extra CPU was coming from in my previous PR (#10) with threadpools: an active `rodio::OutputStream` will constantly service callback requests for data from CoreAudio, and the more threads that have an active context, the more CPU usage we'll use. So to tackle that:
1. I found that the threadpool (with more than one thread) was unnecessary in the first place, because using `rodio::Sink`s enables queuing up multiple sounds on a single `OutputStream`.
2. In addition, because `CoreAudio` itself uses a lot of CPU when you have any contexts open at a single time, then I implemented logic to terminate the worker thread (and discard it's rodio context) after 20 seconds of inactivity and start it up again fresh the next time the user pushes a key.