### PR TITLE
Debounce keystrokes so we don't keep playing on held down keys

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,15 @@
-use rdev::{ listen, Event };
+use rdev::{listen, Event};
 use serde_json;
+use serde_json::{Map, Value};
 use std::env;
 use std::error::Error;
 use std::fs;
-use serde_json::{ Value, Map };
 
-mod play_sound;
 mod keycode;
+mod play_sound;
 
-pub use crate::play_sound::sound;
 pub use crate::keycode::key_code;
+pub use crate::play_sound::sound;
 
 fn initialize_json(path: &str) -> Result<Map<String, Value>, Box<dyn Error>> {
     let config = fs::read_to_string(path)?;
@@ -19,7 +19,7 @@ fn initialize_json(path: &str) -> Result<Map<String, Value>, Box<dyn Error>> {
 }
 
 pub struct JSONFile {
-    pub value: Option<serde_json::Map<std::string::String, serde_json::Value>>
+    pub value: Option<serde_json::Map<std::string::String, serde_json::Value>>,
 }
 
 impl JSONFile {
@@ -33,8 +33,10 @@ impl JSONFile {
         match &self.value {
             Some(value) => {
                 callback(event, value.clone());
-            },
-            None => { println!("JSON wasn't initialized"); }
+            }
+            None => {
+                println!("JSON wasn't initialized");
+            }
         }
     }
 }
@@ -44,7 +46,7 @@ fn main() {
 
     if args.len() != 2 {
         println!(
-r#"
+            r#"
 ██████  ██    ██ ███████ ████████ ██    ██ ██    ██ ██ ██████  ███████ ███████ 
 ██   ██ ██    ██ ██         ██     ██  ██  ██    ██ ██ ██   ██ ██      ██      
 ██████  ██    ██ ███████    ██      ████   ██    ██ ██ ██████  █████   ███████ 
@@ -52,23 +54,28 @@ r#"
 ██   ██  ██████  ███████    ██       ██      ████   ██ ██████  ███████ ███████
 
 Usage: rustyvibes <soundpack_path>
-"#);
-
+"#
+        );
     } else {
-
         {
             #[cfg(any(target_os = "macos", target_os = "linux"))]
-            unsafe { use libc::nice; nice(-20) };
+            unsafe {
+                use libc::nice;
+                nice(-20)
+            };
         }
 
         {
             #[cfg(target_os = "windows")]
-            { use thread_priority::*; assert!(set_current_thread_priority(ThreadPriority::Max).is_ok()); }
+            {
+                use thread_priority::*;
+                assert!(set_current_thread_priority(ThreadPriority::Max).is_ok());
+            }
         }
-        
+
         let mut json_file = JSONFile { value: None };
         json_file.initialize();
-        
+
         println!("Soundpack configuration loaded");
         println!("Rustyvibes is running");
 
@@ -82,27 +89,45 @@ Usage: rustyvibes <soundpack_path>
     }
 }
 
+use once_cell::sync::Lazy;
+use std::collections::HashSet;
+use std::sync::Mutex;
+
+static KEY_DEPRESSED: Lazy<Mutex<HashSet<i32>>> = Lazy::new(|| Mutex::new(HashSet::new()));
+
 fn callback(event: Event, json_file: serde_json::Map<std::string::String, serde_json::Value>) {
     match event.event_type {
         rdev::EventType::KeyPress(key) => {
-            let args: Vec<String> = env::args().collect();
-            let directory = args[1].clone();
             let key_code = key_code::code_from_key(key);
-           
-            let mut dest = match key_code {
-                Some(code) => {
-                    json_file["defines"][&code.to_string()].to_string()
-                },
-                None => {
-                    println!("Unmapped key: {:?}", key);    // for debugging
-                    let default_key = 30;   // keycode for 'a'
-                    json_file["defines"][&default_key.to_string()].to_string()                           
-                }
-            };
-            dest.remove(0);
-            dest.remove(dest.len() - 1);
-            sound::play_sound(format!("{}/{}", directory, dest));
-        },
-        _ => ()
+            let key_down = KEY_DEPRESSED
+                .lock()
+                .expect("Can't open key_depressed set")
+                .insert(key_code.unwrap_or(0));
+            if key_down {
+                let args: Vec<String> = env::args().collect();
+                let directory = args[1].clone();
+
+                let mut dest = match key_code {
+                    Some(code) => json_file["defines"][&code.to_string()].to_string(),
+                    None => {
+                        println!("Unmapped key: {:?}", key); // for debugging
+                        let default_key = 30; // keycode for 'a'
+                        json_file["defines"][&default_key.to_string()].to_string()
+                    }
+                };
+                dest.remove(0);
+                dest.remove(dest.len() - 1);
+                sound::play_sound(format!("{}/{}", directory, dest));
+            }
+        }
+        rdev::EventType::KeyRelease(key) => {
+            let key_code = key_code::code_from_key(key);
+            KEY_DEPRESSED
+                .lock()
+                .expect("Can't open key_depressed set for removal")
+                .remove(&key_code.unwrap_or(0));
+            // println!("In the future, this'll trigger the keyup sound")
+        }
+        _ => (),
     }
 }


### PR DESCRIPTION
Later, I want to actually split the audio file into the downward key press and the release, and then play them separately, but this will at least prevent repeated sounds while holding down a key.