### PR TITLE
Added wayland support using 'unstable grab' in rdev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rdev = "0.5.3"
+rdev = { version = "0.5.3", features = ["unstable_grab"]}
 serde_json = "1.0.120"
 serde = { version = "1.0.203", features = ["derive"] }
 libc = "0.2.155"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Fedora
 sudo dnf install alsa-lib-devel
 ```
 
+### Wayland Support
+Global Wayland support has limitations:
+  - Will not work if you use any key remapper (like keyd, kmonad, etc)
+  - Latency is increased by noticeable amount
+
+To use it
 
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -24,13 +24,6 @@ Fedora
 sudo dnf install alsa-lib-devel
 ```
 
-### Wayland Support
-Global Wayland support has limitations:
-  - Will not work if you use any key remapper (like keyd, kmonad, etc)
-  - Latency is increased by noticeable amount
-
-To use it
-
 
 # Usage
 
@@ -39,6 +32,23 @@ rustyvibes <soundpack_path> -v <volume> (0-100 | optional)
 ```
 
 ### Download Soundpacks: [Here](https://drive.google.com/file/d/1LQEQ9aOVQAs_wgVecXkjaA9K4LXnCdp_/view?usp=sharing)
+
+## Wayland Support
+Global Wayland support has limitations:
+  - Will not work if you use any key remapper (like keyd, kmonad, etc)
+  - Latency is increased by noticeable amount
+
+To use it, first add the user to `input` group using this command:
+```
+sudo usermod -a -G input $USER
+```
+
+Then **Login and Logout** to apply the changes
+
+Then run the command with the `--wayland` flag
+```
+rustyvibes <soundpack_path> -v <volume> (0-100 | optional) --wayland
+```
 
 ---
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -17,5 +17,10 @@ pub struct ArgParser {
     /// The volume to be set. 
     /// Default: 100
     #[arg(short, long)]
-    pub volume: Option<u16>
+    pub volume: Option<u16>,
+
+    /// Use unstable_grab for wayland
+    /// Default: false
+    #[arg(long, default_value_t = false)]
+    pub wayland: bool
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -19,7 +19,7 @@ pub struct ArgParser {
     #[arg(short, long)]
     pub volume: Option<u16>,
 
-    /// Use unstable_grab for wayland
+    /// Enable wayland support (Experimental).
     /// Default: false
     #[arg(long, default_value_t = false)]
     pub wayland: bool

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ fn main() {
     let a = ArgParser::parse();
     let soundpack = a.soundpack;
     let vol = a.volume.or(Some(100)).unwrap();
+    let using_wayland = a.wayland;
 
-    start::rustyvibes::start_rustyvibes(soundpack, vol);
+    start::rustyvibes::start_rustyvibes(soundpack, vol, using_wayland);
 }


### PR DESCRIPTION
Fixes: #23 
Uses rdev builtin [unstable_grab](https://github.com/Narsil/rdev?tab=readme-ov-file#grabbing-global-events-requires-unstable_grab-feature) feature to get the global events from `evdev` library when the `--wayland` flag is passed.
It requires user to be in `input` group(recommended) or give root permissions.

Limitations:
 - It doesn't work with key remapper daemons like keyd, kmonad, etc.
 - Latency gets increased when using this flag.